### PR TITLE
Fix cache suffix in build-multi-architecture

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,7 +50,7 @@ jobs:
         id: cache
         with:
           image: ${{ inputs.image }}/cache
-          tag-suffix: ${{ inputs.suffix }}
+          flavor: ${{ inputs.flavor }}
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
       - uses: docker/build-push-action@v3


### PR DESCRIPTION
## Problem to solve
When build-multi-architecture workflow is called, it writes amd64 and arm64 caches to same image tag.
